### PR TITLE
Use setImmediate when process.nextTick is undefined.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,11 @@ export class Semaphore {
                 });
             };
             this.tasks.push(task);
-            process.nextTick(this.sched.bind(this));
+            if (process && process.nextTick) {
+                process.nextTick(this.sched.bind(this));
+            } else {
+                setImmediate(this.sched.bind(this));
+            }
         });
     }
 


### PR DESCRIPTION
Hi, await-semaphone is cool :)

I want to use on ReactNative. ReactNative's JavaScript Runtime (JavaScriptCore on iOS, Android) is not define process.nextTick. but setImmediate is defined.
