### PR TITLE
Remove unused variable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ export class Semaphore {
     }
 
     public acquire() {
-        return new Promise<() => void>((res, rej) => {
+        return new Promise<() => void>((res, _) => {
             var task = () => {
                 var released = false;
                 res(() => {


### PR DESCRIPTION
The variable "rej" is not used, this creates compile errors if typescript is set to check that.
"node_modules/await-semaphore/index.ts(22,46): error TS6133: 'rej' is declared but its value is never read."